### PR TITLE
Remove unwanted space below "get Dash" image

### DIFF
--- a/src/scss/pages/_home.scss
+++ b/src/scss/pages/_home.scss
@@ -130,7 +130,7 @@ $homeSectionPaddingTop: 80px;
 		}
 	}
 
-	.home-get-started-cta {
+	section.home-get-started-cta {
 		background-color: $color-blue;
 		color: white;
 		padding-bottom: 0;


### PR DESCRIPTION
I increased the specificity of a rule that used to remove the space below the "get Dash" image on the front page, so it is once again effective.